### PR TITLE
- clean up of data, score and sound logic

### DIFF
--- a/zoo-escape/Scripts/Components/Interactive/Steak.gd
+++ b/zoo-escape/Scripts/Components/Interactive/Steak.gd
@@ -8,10 +8,9 @@ func _ready() -> void:
 	$Area2D.body_entered.connect(bodyEntered)
 
 
-# if the player enter the area delete itself
+# if the player enters the area delete itself
 func bodyEntered(body: Node2D) -> void:
 	if body.is_in_group("ZEPlayer"):
-		var _oldScore : int = Globals.currentGameData.get("player_score") # QUERY: Should scoring be handled by a steak or by a more significant node, such as the GameRoot?
-		Globals.currentGameData.set("player_score",_oldScore + bonus)
-		SoundControl.playSfx(SoundControl.pickup)
+		Globals.scoreUpdate(bonus,true) # global score update
+		SoundControl.playSfx(SoundControl.pickup) # global sound call
 		queue_free()

--- a/zoo-escape/Scripts/Components/Interactive/Steak.gd
+++ b/zoo-escape/Scripts/Components/Interactive/Steak.gd
@@ -11,6 +11,6 @@ func _ready() -> void:
 # if the player enters the area delete itself
 func bodyEntered(body: Node2D) -> void:
 	if body.is_in_group("ZEPlayer"):
-		Globals.scoreUpdate(bonus,true) # global score update
+		Globals.scoreUpdate(bonus, true) # global score update
 		SoundControl.playSfx(SoundControl.pickup) # global sound call
 		queue_free()

--- a/zoo-escape/Scripts/Core/Data.gd
+++ b/zoo-escape/Scripts/Core/Data.gd
@@ -54,7 +54,7 @@ func defaultGameData() -> void:
 	Globals.highScoreboardNames = DEFAULT_NAMES.duplicate()
 	Globals.highScoreboardValues = DEFAULT_VALUES.duplicate()
 	Globals.deadzoneUpdate()
-	SoundControl.setSoundPreferences(DEFAULT_VOLUME,DEFAULT_VOLUME,DEFAULT_VOLUME,DEFAULT_VOLUME)
+	SoundControl.setSoundPreferences(DEFAULT_VOLUME, DEFAULT_VOLUME, DEFAULT_VOLUME, DEFAULT_VOLUME)
 	SoundControl.resetMusicFade()
 
 
@@ -68,14 +68,16 @@ func loadData()-> void:
 		saveData = JSON.parse_string(access.get_as_text())
 		print("Data loaded!")
 		access.close()
-		## apply settings
+		## update global values
 		Globals.currentSettings["master_volume"] = saveData.master_volume
 		Globals.currentSettings["music_volume"] = saveData.music_volume
 		Globals.currentSettings["sfx_volume"] = saveData.sfx_volume
 		Globals.currentSettings["cue_volume"] = saveData.cue_volume
 		Globals.currentSettings["analog_deadzone"] = saveData.analog_deadzone
+		## update settings
 		Globals.deadzoneUpdate()
-		SoundControl.setSoundPreferences(saveData.master_volume,saveData.music_volume,saveData.sfx_volume,saveData.cue_volume)
+		SoundControl.setSoundPreferences(saveData.master_volume, saveData.music_volume, 
+		saveData.sfx_volume, saveData.cue_volume)
 		SoundControl.resetMusicFade()
 		# copy high score arrays
 		Globals.highScoreboardValues = saveData.highScoreboardValues.duplicate()

--- a/zoo-escape/Scripts/Core/Data.gd
+++ b/zoo-escape/Scripts/Core/Data.gd
@@ -53,6 +53,9 @@ func defaultGameData() -> void:
 	Globals.currentSettings["analog_deadzone"] = DEFAULT_DZ
 	Globals.highScoreboardNames = DEFAULT_NAMES.duplicate()
 	Globals.highScoreboardValues = DEFAULT_VALUES.duplicate()
+	Globals.deadzoneUpdate()
+	SoundControl.setSoundPreferences(DEFAULT_VOLUME,DEFAULT_VOLUME,DEFAULT_VOLUME,DEFAULT_VOLUME)
+	SoundControl.resetMusicFade()
 
 
 # load with check
@@ -65,11 +68,15 @@ func loadData()-> void:
 		saveData = JSON.parse_string(access.get_as_text())
 		print("Data loaded!")
 		access.close()
+		## apply settings
 		Globals.currentSettings["master_volume"] = saveData.master_volume
 		Globals.currentSettings["music_volume"] = saveData.music_volume
 		Globals.currentSettings["sfx_volume"] = saveData.sfx_volume
 		Globals.currentSettings["cue_volume"] = saveData.cue_volume
 		Globals.currentSettings["analog_deadzone"] = saveData.analog_deadzone
+		Globals.deadzoneUpdate()
+		SoundControl.setSoundPreferences(saveData.master_volume,saveData.music_volume,saveData.sfx_volume,saveData.cue_volume)
+		SoundControl.resetMusicFade()
 		# copy high score arrays
 		Globals.highScoreboardValues = saveData.highScoreboardValues.duplicate()
 		Globals.highScoreboardNames = saveData.highScoreboardNames.duplicate()

--- a/zoo-escape/Scripts/Core/GameRoot.gd
+++ b/zoo-escape/Scripts/Core/GameRoot.gd
@@ -2,20 +2,12 @@ class_name GameRoot extends Node2D
 
 @onready var aniPlayer: AnimationPlayer = $AnimationPlayer
 var title := load(Scenes.TITLE)
-var bgmLevel: float
-var sfxLevel: float
-var cueLevel: float
-var masterLevel: float
+
 
 func _ready() -> void:
 	SceneManager.gameRoot = self
 	aniPlayer.play("RESET")
 	SoundControl.resetMusicFade() # reset music state
-	Globals.currentGameData["player_score"] = 0
-	bgmLevel = SoundControl.bgmLevel # This should not be here.  Volume control should be in SoundControl.gd only.
-	sfxLevel = SoundControl.sfxLevel # This should not be here.  Volume control should be in SoundControl.gd only.
-	cueLevel = SoundControl.cueLevel # This should not be here.  Volume control should be in SoundControl.gd only.
-	masterLevel = SoundControl.masterLevel # This should not be here.  Volume control should be in SoundControl.gd only.
 
 
 # Called to progress the game to the next sceene
@@ -25,8 +17,7 @@ func GoToNextScene(OldScene: Node, NewScene: PackedScene) -> void:
 	set_physics_process(false)
 	aniPlayer.play("FadeOut")
 	await aniPlayer.animation_finished # wait until animation finish before change
-	
-	SoundControl.setSoundPreferences(masterLevel,bgmLevel,sfxLevel,cueLevel)
+
 	OldScene.queue_free() # free old scene
 	var newCurrentScene := NewScene.instantiate()
 	add_child(newCurrentScene) # add new scene
@@ -45,7 +36,6 @@ func ReturnToTitle() -> void:
 	aniPlayer.play("FadeOut")
 	await aniPlayer.animation_finished
 
-	SoundControl.setSoundPreferences(masterLevel,bgmLevel,sfxLevel,cueLevel)
 	get_tree().reload_current_scene()
 
 	aniPlayer.play("FadeIn") # restore processing on animation end

--- a/zoo-escape/Scripts/Core/GameRoot.gd
+++ b/zoo-escape/Scripts/Core/GameRoot.gd
@@ -11,7 +11,7 @@ func _ready() -> void:
 
 
 # Called to progress the game to the next sceene
-func GoToNextScene(OldScene: Node, NewScene: PackedScene) -> void:
+func goToNextScene(OldScene: Node, NewScene: PackedScene) -> void:
 	# start the Fade out , close processing
 	set_process_input(false)
 	set_physics_process(false)
@@ -30,7 +30,7 @@ func GoToNextScene(OldScene: Node, NewScene: PackedScene) -> void:
 
 
 # Called to return to the game's Title scene
-func ReturnToTitle() -> void:
+func returnToTitle() -> void:
 	set_process_input(false) # end processing, just like new scene
 	set_physics_process(false)
 	aniPlayer.play("FadeOut")

--- a/zoo-escape/Scripts/Core/Globals.gd
+++ b/zoo-escape/Scripts/Core/Globals.gd
@@ -92,9 +92,9 @@ func scoreUpdate(value:int,buff:bool) -> void:
 	var _scoreCheck : int = currentGameData.get("player_score") # get current score
 	var _newScore : int # create holder for totaling
 	if buff == true: # is it a buff?
-		_newScore = _scoreCheck+value # add
+		_newScore = _scoreCheck + value # add
 	else:
-		_newScore = _scoreCheck-value # or subtract
+		_newScore = _scoreCheck - value # or subtract
 
 	currentGameData.set("player_score",_newScore) # then update global
 
@@ -102,7 +102,7 @@ func scoreUpdate(value:int,buff:bool) -> void:
 # global function to update input deadzones
 func deadzoneUpdate() -> void:
 	var _deadzone : float = currentSettings.get("analog_deadzone")
-	InputMap.action_set_deadzone("DigitalLeft",_deadzone)
-	InputMap.action_set_deadzone("DigitalDown",_deadzone)
-	InputMap.action_set_deadzone("DigitalRight",_deadzone)
-	InputMap.action_set_deadzone("DigitalUp",_deadzone)
+	InputMap.action_set_deadzone("DigitalLeft", _deadzone)
+	InputMap.action_set_deadzone("DigitalDown", _deadzone)
+	InputMap.action_set_deadzone("DigitalRight", _deadzone)
+	InputMap.action_set_deadzone("DigitalUp", _deadzone)

--- a/zoo-escape/Scripts/Core/Globals.gd
+++ b/zoo-escape/Scripts/Core/Globals.gd
@@ -85,3 +85,24 @@ var highScoreboardValues = [
 	17000,
 	16000
 ]
+
+
+# global function for changing score, with bool for determining plus/minus
+func scoreUpdate(value:int,buff:bool) -> void:
+	var _scoreCheck : int = currentGameData.get("player_score") # get current score
+	var _newScore : int # create holder for totaling
+	if buff == true: # is it a buff?
+		_newScore = _scoreCheck+value # add
+	else:
+		_newScore = _scoreCheck-value # or subtract
+
+	currentGameData.set("player_score",_newScore) # then update global
+
+
+# global function to update input deadzones
+func deadzoneUpdate() -> void:
+	var _deadzone : float = currentSettings.get("analog_deadzone")
+	InputMap.action_set_deadzone("DigitalLeft",_deadzone)
+	InputMap.action_set_deadzone("DigitalDown",_deadzone)
+	InputMap.action_set_deadzone("DigitalRight",_deadzone)
+	InputMap.action_set_deadzone("DigitalUp",_deadzone)

--- a/zoo-escape/Scripts/Core/Hud.gd
+++ b/zoo-escape/Scripts/Core/Hud.gd
@@ -219,7 +219,7 @@ func _on_open_timer_timeout() -> void:
 # button for restart
 func _on_restart_button_pressed() -> void:
 	$HudWindow.visible = false # hide window to avoid artifacting/bugs
-	SoundControl.playCue(SoundControl.flutter,3.0)
+	SoundControl.playCue(SoundControl.flutter, 3.0)
 	buttonsDisabled()
 	SoundControl.resetMusicFade()
 	restart_room.emit() # signal to levelManager to reload
@@ -228,7 +228,7 @@ func _on_restart_button_pressed() -> void:
 # button for exiting the game
 func _on_exit_button_pressed() -> void:
 	$HudWindow.visible = false
-	SoundControl.playCue(SoundControl.ruined,0.5)
+	SoundControl.playCue(SoundControl.ruined, 0.5)
 	buttonsDisabled()
 	SoundControl.resetMusicFade()
 	exit_game.emit() # signal to levelManager to exit to title
@@ -271,13 +271,13 @@ func scoreProcessing() -> void:
 		SCORE_PROCESS_STATES.TIME_PROCESS:
 			if timerValue > 0: # timer adds bonus until zero
 				timerValue -= 1
-				Globals.scoreUpdate(secondBonus,true)
+				Globals.scoreUpdate(secondBonus, true)
 			else:
 				scoreProcessState = SCORE_PROCESS_STATES.MOVE_PROCESS # then state flips
 		SCORE_PROCESS_STATES.MOVE_PROCESS:
 			if movesValue > 0: # moves subtract penalty until zero
 				movesValue-=1
-				Globals.scoreUpdate(movePenalty,false)
+				Globals.scoreUpdate(movePenalty, false)
 			else: # then state flips back to off
 				print("Score processed!")
 				score_processed.emit() # after emitting one signal

--- a/zoo-escape/Scripts/Core/Hud.gd
+++ b/zoo-escape/Scripts/Core/Hud.gd
@@ -271,21 +271,20 @@ func scoreProcessing() -> void:
 		SCORE_PROCESS_STATES.TIME_PROCESS:
 			if timerValue > 0: # timer adds bonus until zero
 				timerValue -= 1
-				var _old: int = Globals.currentGameData.get("player_score")
-				Globals.currentGameData.set("player_score", (_old + secondBonus))
+				Globals.scoreUpdate(secondBonus,true)
 			else:
 				scoreProcessState = SCORE_PROCESS_STATES.MOVE_PROCESS # then state flips
 		SCORE_PROCESS_STATES.MOVE_PROCESS:
 			if movesValue > 0: # moves subtract penalty until zero
 				movesValue-=1
-				var _old2 = Globals.currentGameData.get("player_score")
-				Globals.currentGameData.set("player_score", (_old2-movePenalty))
+				Globals.scoreUpdate(movePenalty,false)
 			else: # then state flips back to off
 				print("Score processed!")
 				score_processed.emit() # after emitting one signal
 				scoreProcessState = SCORE_PROCESS_STATES.POST
 		SCORE_PROCESS_STATES.POST:
 			pass
+			# empty state to end processing
 
 
 # grab mouse focus for restart

--- a/zoo-escape/Scripts/Core/Password.gd
+++ b/zoo-escape/Scripts/Core/Password.gd
@@ -39,9 +39,9 @@ func _ready() -> void:
 		$Animator.play("fade_in")
 		$InputBufferTimer.start()
 		$ButtonBox/Button1.grab_focus()
-		allStatesFlywheel(true,true) # all hud flags true with animation in
+		allStatesFlywheel(true, true) # all hud flags true with animation in
 	else:
-		allStatesFlywheel(false,false) # hud flags off but no animation
+		allStatesFlywheel(false, false) # hud flags off but no animation
 		self.position = correctedVector
 
 
@@ -58,12 +58,12 @@ func _input(_event: InputEvent) -> void:
 					$InputBufferTimer.start()
 					$ButtonBox/Button1.grab_focus()
 					buttonBatchControl(true)
-					allStatesFlywheel(true,true) # open all hud states, animation in
+					allStatesFlywheel(true, true) # open all hud states, animation in
 				else:
 					buttonBatchControl(false)
-					allStatesFlywheel(false,true)
+					allStatesFlywheel(false, true)
 			else: # close all states with animation out
-				allStatesFlywheel(false,true)
+				allStatesFlywheel(false, true)
 		
 	if inGameMode and windowOpenFlag == true:
 		fetchInput()
@@ -144,7 +144,7 @@ func randomBlipCue() -> void:
 # grabbing global input
 func fetchInput() -> void:
 	if Input.is_action_just_pressed("PasswordButton"):
-		SoundControl.playCue(SoundControl.down,2.0)
+		SoundControl.playCue(SoundControl.down, 2.0)
 		if inGameMode and !windowOpenFlag:
 			get_tree().paused = true
 			$Animator.play_backwards("fade_in")
@@ -165,10 +165,9 @@ func fetchInput() -> void:
 				$ButtonBox/ButtonEnter.grab_focus()
 			
 		if Globals.PASSWORDS.has(code.text): # if level code correct, show feedback
-			SoundControl.playCue(SoundControl.success,2.5)
+			SoundControl.playCue(SoundControl.success, 2.5)
 			code.material = correctShader
 			code.modulate = Color.GREEN_YELLOW
-			Globals.currentGameData["player_score"] = 0 # NOTE:  Why is this happening here instead of in the GameRoot or somewhere besides a menu?
 			$LoadSceneBuffer.start(loadSceneBufferTime) # begin buffer to load
 			
 		if !"-" in code.text: # if no blanks, go to enter button
@@ -182,7 +181,8 @@ func fetchInput() -> void:
 			codeRemoval()
 		else:
 			buttonBatchControl(false)
-			allStatesFlywheel(false,true)
+			allStatesFlywheel(false, true)
+			## TODO: May soon be obsolete due to new global value
 			if !inGameMode: # if in from frontend, return thru frontend
 				returnToTitle()
 
@@ -210,7 +210,7 @@ func buttonBatchControl(logic:bool) -> void:
 # return sound cue and load function
 func returnToTitle() -> void:
 	SoundControl.playCue(SoundControl.down, 1.4)
-	SceneManager.call_deferred("GoToNewSceneString", title)
+	SceneManager.call_deferred("goToNewSceneString", title)
 
 
 # check code for answer
@@ -231,7 +231,7 @@ func answerCheck() -> void:
 
 # load scene at end of load buffer timer
 func _on_load_scene_buffer_timeout() -> void:
-	SceneManager.call_deferred("GoToNewSceneString", Globals.PASSWORDS[code.text])
+	SceneManager.call_deferred("goToNewSceneString", Globals.PASSWORDS[code.text])
 
 
 # get number by state and input
@@ -441,7 +441,7 @@ func _on_button_clear_pressed() -> void:
 		if !inGameMode:
 			returnToTitle()
 		else:
-			allStatesFlywheel(false,true)
+			allStatesFlywheel(false, true)
 
 
 # Called when Clear button focused

--- a/zoo-escape/Scripts/Core/SceneManager.gd
+++ b/zoo-escape/Scripts/Core/SceneManager.gd
@@ -16,27 +16,27 @@ func _ready() -> void:
 
 
 # this takes a loaded scene as argument and unpauses the tree
-func GoToNewScenePacked(newScene: PackedScene) -> void:
+func goToNewScenePacked(newScene: PackedScene) -> void:
 	# Before switching to another scene, make sure the scene tree is not paused
 	# This happens if a game is exited while paused
 	get_tree().paused = false
 	
 	# Switch the scenes
-	gameRoot.GoToNextScene(currentScene, newScene)
+	gameRoot.goToNextScene(currentScene, newScene)
 
 
 # this takes a filename/string as argument and loads it with the previous function
-func GoToNewSceneString(newScene: String) -> void:
+func goToNewSceneString(newScene: String) -> void:
 	# TODO: add error checking
 	var scene: Resource = load(newScene)
-	GoToNewScenePacked(scene)
+	goToNewScenePacked(scene)
 
 
 # this returns to the title
-func GoToTitle() -> void:
-	GoToNewSceneString(TITLE)
+func goToTitle() -> void:
+	goToNewSceneString(TITLE)
 
 
 # this goes to the settings menu
-func GoToSettings() -> void:
-	GoToNewSceneString(SETTINGS)
+func goToSettings() -> void:
+	goToNewSceneString(SETTINGS)

--- a/zoo-escape/Scripts/Core/SceneManager.gd
+++ b/zoo-escape/Scripts/Core/SceneManager.gd
@@ -8,26 +8,27 @@ const TITLE := Scenes.TITLE
 const SETTINGS := Scenes.SETTINGS
 
 
+# Set the root node so it (and its children set to Inherit mode) cannot be paused
+# Inherit mode is default for Nodes, so set your game node's mode to Pausable
 func _ready() -> void:
-	# Set the root node so it (and its children set to Inherit mode) cannot be paused
-	# Inherit mode is default for Nodes, so set your game node's mode to Pausable
 	get_parent().process_mode = Node.PROCESS_MODE_ALWAYS
 
 
+
 # this takes a loaded scene as argument and unpauses the tree
-func GoToNewScenePacked(NewScene: PackedScene) -> void:
+func GoToNewScenePacked(newScene: PackedScene) -> void:
 	# Before switching to another scene, make sure the scene tree is not paused
 	# This happens if a game is exited while paused
 	get_tree().paused = false
 	
 	# Switch the scenes
-	gameRoot.GoToNextScene(currentScene, NewScene)
+	gameRoot.GoToNextScene(currentScene, newScene)
 
 
 # this takes a filename/string as argument and loads it with the previous function
-func GoToNewSceneString(NewScene: String) -> void:
+func GoToNewSceneString(newScene: String) -> void:
 	# TODO: add error checking
-	var scene: Resource = load(NewScene)
+	var scene: Resource = load(newScene)
 	GoToNewScenePacked(scene)
 
 

--- a/zoo-escape/Scripts/Core/SceneManager.gd
+++ b/zoo-escape/Scripts/Core/SceneManager.gd
@@ -4,7 +4,8 @@ extends Node
 # This is set by gameroot when it is ready
 @onready var gameRoot: GameRoot
 @onready var currentScene: Node
-const TITLE = Scenes.TITLE
+const TITLE := Scenes.TITLE
+const SETTINGS := Scenes.SETTINGS
 
 
 func _ready() -> void:
@@ -13,6 +14,7 @@ func _ready() -> void:
 	get_parent().process_mode = Node.PROCESS_MODE_ALWAYS
 
 
+# this takes a loaded scene as argument and unpauses the tree
 func GoToNewScenePacked(NewScene: PackedScene) -> void:
 	# Before switching to another scene, make sure the scene tree is not paused
 	# This happens if a game is exited while paused
@@ -22,11 +24,18 @@ func GoToNewScenePacked(NewScene: PackedScene) -> void:
 	gameRoot.GoToNextScene(currentScene, NewScene)
 
 
+# this takes a filename/string as argument and loads it with the previous function
 func GoToNewSceneString(NewScene: String) -> void:
 	# TODO: add error checking
 	var scene: Resource = load(NewScene)
 	GoToNewScenePacked(scene)
 
 
+# this returns to the title
 func GoToTitle() -> void:
 	GoToNewSceneString(TITLE)
+
+
+# this goes to the settings menu
+func GoToSettings() -> void:
+	GoToNewSceneString(SETTINGS)

--- a/zoo-escape/Scripts/Core/Settings.gd
+++ b/zoo-escape/Scripts/Core/Settings.gd
@@ -64,7 +64,7 @@ func _ready() -> void:
 	
 	# grab first focus and roll in info text
 	$MasterGroup/MasterSlider.grab_focus()
-	focusInfoRelay("MASTER",masterInfo)
+	focusInfoRelay("MASTER", masterInfo)
 	$Description.text = masterInfo
 	$Animator.play("roll_info")
 
@@ -74,17 +74,17 @@ func _process(_delta: float) -> void: # single button fast value scroll in deadz
 	if !bufferState:
 		if Input.is_action_pressed("ActionButton") and focusGroup == FOCUS_GROUPS.DEADZONE:
 			if $DeadzoneGroup/DeadzoneDown.has_focus() and analogDeadzone > DEADZONE_MIN:
-				analogDeadzone-=0.01 # adjust deadzone and update text
+				analogDeadzone -= 0.01 # adjust deadzone and update text
 				$DeadzoneGroup/DeadzoneValue.text = str(analogDeadzone)
 			if $DeadzoneGroup/DeadzoneUp.has_focus() and analogDeadzone < DEADZONE_MAX:
-				analogDeadzone+=0.01
+				analogDeadzone += 0.01
 				$DeadzoneGroup/DeadzoneValue.text = str(analogDeadzone)
 	
 		if Input.is_action_just_released("DigitalLeft") or Input.is_action_just_released("DigitalRight"):
 			if focusGroup == FOCUS_GROUPS.SFX: # add sound cues to test fx levels
 				SoundControl.playSfx(SoundControl.scratch)
 			if focusGroup == FOCUS_GROUPS.CUE:
-				SoundControl.playCue(SoundControl.pickup,1.0)
+				SoundControl.playCue(SoundControl.pickup, 1.0)
 	
 		if Input.is_action_just_pressed("CancelButton") or Input.is_action_just_pressed("PasswordButton"):
 			if focusGroup != FOCUS_GROUPS.ESCAPE: # move to escape button on press
@@ -253,18 +253,18 @@ func _on_cue_slider_mouse_entered() -> void:
 
 # cue test on drag
 func _on_cue_slider_drag_started() -> void:
-	SoundControl.playCue(SoundControl.pickup,1.0) # audio cue for testing on grab
+	SoundControl.playCue(SoundControl.pickup, 1.0) # audio cue for testing on grab
 
 
 # cue test on release
 func _on_cue_slider_drag_ended(_value_changed: bool) -> void:
-	SoundControl.playCue(SoundControl.pickup,1.0) # audio cue for testing after release
+	SoundControl.playCue(SoundControl.pickup, 1.0) # audio cue for testing after release
 
 
 # update deadzone levels
 func _on_deadzone_down_pressed() -> void:
 	if !bufferState:
-		var _downValue := analogDeadzone-0.01
+		var _downValue := analogDeadzone - 0.01
 		if _downValue < DEADZONE_MIN:
 			_downValue = DEADZONE_MIN
 

--- a/zoo-escape/Scripts/Core/Settings.gd
+++ b/zoo-escape/Scripts/Core/Settings.gd
@@ -310,7 +310,7 @@ func _on_escape_button_pressed() -> void:
 	if !bufferState:
 		Data.saveGameData()
 		globalSettingsUpdate() # update global settings
-		SceneManager.GoToTitle() # go to title
+		SceneManager.goToTitle() # go to title
 
 
 # grab escape button focus

--- a/zoo-escape/Scripts/Core/Settings.gd
+++ b/zoo-escape/Scripts/Core/Settings.gd
@@ -42,8 +42,6 @@ var focusGroup := FOCUS_GROUPS.MASTER # shows which control area has focus
 func _ready() -> void:
 	# update text and set first button on master bgm down
 	# update all text and values with globals from load data
-	Data.loadData()
-	SoundControl.setSoundPreferences(masterVolume, bgmVolume, sfxVolume, cueVolume)
 	
 	# update percents
 	masterPercent = percentageConversion(masterVolume)
@@ -103,12 +101,10 @@ func globalSettingsUpdate() -> void: # update global settings
 	Globals.currentSettings["sfx_volume"] = sfxVolume
 	Globals.currentSettings["cue_volume"] = cueVolume
 	Globals.currentSettings["analog_deadzone"] = analogDeadzone
+	# set sound levels
 	SoundControl.setSoundPreferences(masterVolume, bgmVolume, sfxVolume, cueVolume)
 	# set deadzones
-	InputMap.action_set_deadzone("DigitalDown", analogDeadzone)
-	InputMap.action_set_deadzone("DigitalUp", analogDeadzone)
-	InputMap.action_set_deadzone("DigitalLeft", analogDeadzone)
-	InputMap.action_set_deadzone("DigitalRight", analogDeadzone)
+	Globals.deadzoneUpdate()
 
 
 # focus info widget to update info text on focus change
@@ -274,7 +270,7 @@ func _on_deadzone_down_pressed() -> void:
 
 		analogDeadzone = _downValue
 		$DeadzoneGroup/DeadzoneValue.text = str(analogDeadzone)
-		globalSettingsUpdate()
+		Globals.deadzoneUpdate()
 
 
 # grab deadzone focus
@@ -296,7 +292,7 @@ func _on_deadzone_up_pressed() -> void:
 
 		analogDeadzone = _upValue
 		$DeadzoneGroup/DeadzoneValue.text = str(analogDeadzone)
-		globalSettingsUpdate()
+		Globals.deadzoneUpdate()
 
 
 # grab deadzone focus

--- a/zoo-escape/Scripts/Core/SoundControl.gd
+++ b/zoo-escape/Scripts/Core/SoundControl.gd
@@ -60,6 +60,8 @@ func _process(delta: float) -> void: # listen for fade states and update volumes
 	if !AudioServer.is_bus_mute(3): # check volume reference/bgm bus
 		if fadeState != FADE_STATES.PEAK_VOLUME: # fade trigger if bgm not muted
 			bgmFadingMachine(delta,fadeRate)
+		else:
+			pass
 
 
 # values set for sound levels
@@ -88,7 +90,7 @@ func fadeRateUpdate(_newValue:float) -> void:
 	fadeRate = _newValue
 
 
-# queue next track and update fade if needed
+# queue next track and update fade if needed (called remotely)
 func levelChangeSoundCall(_value:float, _music:String) -> void:
 	currentBgm = _music # allows music to change on next fade start
 	fadeState = FADE_STATES.OUT_TRIGGER
@@ -99,6 +101,7 @@ func levelChangeSoundCall(_value:float, _music:String) -> void:
 func stopSounds() -> void:
 	bgm.stop()
 	sfx.stop()
+
 
 # call sfx file and play
 func playSfx(_sfxFile:String) -> void:

--- a/zoo-escape/Scripts/Core/Title.gd
+++ b/zoo-escape/Scripts/Core/Title.gd
@@ -13,6 +13,7 @@ func _ready() -> void:
 	SceneManager.currentScene = self
 
 
+
 # listen for exit call from escape button
 func _process(_delta: float) -> void:
 	if OS.get_name() != "Web" && Input.is_action_just_pressed("CancelButton"):
@@ -30,7 +31,7 @@ func _on_new_game_button_pressed() -> void:
 	SceneManager.GoToNewSceneString(Scenes.TUTORIAL1) # This will need to be moved to the menu script when the menu is added
 	Globals.currentGameData.set("player_score", 0) # Why is this being done here AND in GameRoot.gd?!  Let's make a central function to do this type of thing in the GameRoot when a new game starts.
 	# change bgm and fade on out
-	SoundControl.levelChangeSoundCall(1.0, SoundControl.defaultBgm)
+	SoundControl.levelChangeSoundCall(1.0, SoundControl.defaultBgm) # begin bgm fade in
 
 
 # go to password screen after pressing button

--- a/zoo-escape/Scripts/Core/Title.gd
+++ b/zoo-escape/Scripts/Core/Title.gd
@@ -28,7 +28,7 @@ func _process(_delta: float) -> void:
 func _on_new_game_button_pressed() -> void:
 	Data.saveGameData() # save options data
 	SoundControl.playCue(SoundControl.start, 1.0) # audio feedback
-	SceneManager.GoToNewSceneString(Scenes.TUTORIAL1) # This will need to be moved to the menu script when the menu is added
+	SceneManager.goToNewSceneString(Scenes.TUTORIAL1) # This will need to be moved to the menu script when the menu is added
 	Globals.currentGameData.set("player_score", 0) # Why is this being done here AND in GameRoot.gd?!  Let's make a central function to do this type of thing in the GameRoot when a new game starts.
 	# change bgm and fade on out
 	SoundControl.levelChangeSoundCall(1.0, SoundControl.defaultBgm) # begin bgm fade in
@@ -37,13 +37,13 @@ func _on_new_game_button_pressed() -> void:
 # go to password screen after pressing button
 func _on_password_button_pressed() -> void:
 	SoundControl.playCue(SoundControl.zap, 1.0) # audio feedback
-	SceneManager.GoToNewSceneString(Scenes.PASSWORD)
+	SceneManager.goToNewSceneString(Scenes.PASSWORD)
 
 
 # go to settings screen after pressing button
 func _on_settings_button_pressed() -> void:
 	SoundControl.playCue(SoundControl.flutter, 1.0) # audio feedback
-	SceneManager.GoToNewSceneString(Scenes.SETTINGS)
+	SceneManager.goToNewSceneString(Scenes.SETTINGS)
 
 
 # check for warning state. if in warning, exit, else show warning and open state

--- a/zoo-escape/Scripts/Levels/LevelManager.gd
+++ b/zoo-escape/Scripts/Levels/LevelManager.gd
@@ -100,7 +100,7 @@ func nextRoom():
 # update score and apply exit score and bonus
 func allSteaksCollected() -> void:
 	exitTile.activateExit()
-	Globals.scoreUpdate(exitScoreBonus,true)
+	Globals.scoreUpdate(exitScoreBonus, true)
 
 
 # function to close hud and compare original score before reloading the level

--- a/zoo-escape/Scripts/Levels/LevelManager.gd
+++ b/zoo-escape/Scripts/Levels/LevelManager.gd
@@ -15,14 +15,13 @@ class_name ZELevelManager extends Node2D
 var loadingScore: Variant = Globals.currentGameData.get("player_score") # compare score for reloads
 var localHud: Control # pointer for hud
 var timeUp := false # to monitor local hud timer
+@export var levelBgm := "res://Assets/Sound/Theme.ogg"
 
 
 # Called when the node enters the scene tree for the first time.
 func _ready() -> void:
 	SceneManager.currentScene = self
 	self.add_to_group("LevelManager")
-	if !AudioServer.is_bus_mute(3) or SoundControl.bgmLevel > -20:
-		SoundControl.resetMusicFade() # reset music state
 	player.InWater.connect(restartRoom)
 	exitTile.PlayerExits.connect(exitLevel)
 	steakManager.AllSteaksCollected.connect(allSteaksCollected)
@@ -31,8 +30,10 @@ func _ready() -> void:
 	
 	# check to ensure bgm fade level is consistent
 	# if bgm fade level not normal, reset fade state so it fades in
-	if SoundControl.fadeState != SoundControl.FADE_STATES.PEAK_VOLUME:
+	if SoundControl.fadeState != SoundControl.FADE_STATES.PEAK_VOLUME or SoundControl.currentBgm != levelBgm:
 		SoundControl.fadeState = SoundControl.FADE_STATES.IN_TRIGGER
+	
+
 	
 	# connect hud to scene change and score process functions
 	localHud = get_node("Player/ZEHud")
@@ -93,15 +94,13 @@ func nextRoom():
 	if nextLevel != "9990":
 		SceneManager.call_deferred("GoToNewSceneString", Globals.PASSWORDS[nextLevel])
 	else:
-		Globals.currentGameData.set("player_score", 0)
 		exitGame()
 
 
 # update score and apply exit score and bonus
 func allSteaksCollected() -> void:
 	exitTile.activateExit()
-	var _old : int = Globals.currentGameData.get("player_score")
-	Globals.currentGameData.set("player_score", (_old + exitScoreBonus))
+	Globals.scoreUpdate(exitScoreBonus,true)
 
 
 # function to close hud and compare original score before reloading the level
@@ -115,5 +114,5 @@ func restartRoom() -> void:
 
 # game exit function, refers to gameroot function
 func exitGame() -> void:
-	Globals.currentGameData.set("player_score", 0) # reset score to zero on exit
+	Data.saveGameData()
 	SceneManager.call_deferred("GoToNewSceneString", Globals.PASSWORDS[nextLevel])

--- a/zoo-escape/Scripts/Levels/LevelManager.gd
+++ b/zoo-escape/Scripts/Levels/LevelManager.gd
@@ -92,7 +92,7 @@ func exitLevel() -> void:
 # load next level
 func nextRoom():
 	if nextLevel != "9990":
-		SceneManager.call_deferred("GoToNewSceneString", Globals.PASSWORDS[nextLevel])
+		SceneManager.call_deferred("goToNewSceneString", Globals.PASSWORDS[nextLevel])
 	else:
 		exitGame()
 
@@ -109,10 +109,10 @@ func restartRoom() -> void:
 	var _score : int = Globals.currentGameData.get("player_score")
 	if _score != loadingScore:
 		Globals.currentGameData.set("player_score", loadingScore)
-	SceneManager.call_deferred("GoToNewSceneString", Globals.PASSWORDS[levelCode])
+	SceneManager.call_deferred("goToNewSceneString", Globals.PASSWORDS[levelCode])
 
 
 # game exit function, refers to gameroot function
 func exitGame() -> void:
 	Data.saveGameData()
-	SceneManager.call_deferred("GoToNewSceneString", Globals.PASSWORDS[nextLevel])
+	SceneManager.call_deferred("goToNewSceneString", Globals.PASSWORDS[nextLevel])


### PR DESCRIPTION
- obsolete sound levels in game root removed
- sound control logic edited to prevent sound dip between levels
- save and load call reduced to single time at title
- score is now a global function that can be called for modulation in either direction
- deadzones now update in real time instead of complete settings logging
- level manager now has exported music category, allowing us to change tracks between levels