### PR TITLE
Small UI bug fixes for PR 115

### DIFF
--- a/zoo-escape/Scenes/Core/MenuMain.tscn
+++ b/zoo-escape/Scenes/Core/MenuMain.tscn
@@ -1,9 +1,8 @@
-[gd_scene load_steps=10 format=3 uid="uid://cmhbojvsjsq0"]
+[gd_scene load_steps=9 format=3 uid="uid://cmhbojvsjsq0"]
 
 [ext_resource type="Script" uid="uid://b4e8ul7se7xgj" path="res://Scripts/Core/MenuMain.gd" id="1_yuxgg"]
 [ext_resource type="Texture2D" uid="uid://bg626xfxp25i2" path="res://Assets/Images/MainMenuBackground.png" id="2_7a404"]
 [ext_resource type="Script" uid="uid://dubpjf4h8ayup" path="res://Scripts/Core/AnimatedTitleElements.gd" id="3_2i1af"]
-[ext_resource type="FontFile" uid="uid://dltop0cdtk3sp" path="res://Assets/Fonts/PCSenior.ttf" id="3_7a404"]
 [ext_resource type="SpriteFrames" uid="uid://cfu2np5ucp3r5" path="res://Assets/Images/Title/EyeballSpriteFrameset.tres" id="4_kbsxh"]
 [ext_resource type="Theme" uid="uid://c5f45xbhg3i0d" path="res://Assets/UI_Resources/MenuTheme.tres" id="6_kbsxh"]
 
@@ -61,20 +60,17 @@ anchor_right = 1.0
 anchor_bottom = 1.0
 grow_horizontal = 2
 grow_vertical = 2
-color = Color(0.180392, 0.172549, 0.231373, 1)
+color = Color(0.180392, 0.172549, 0.231373, 0.784314)
 metadata/_edit_lock_ = true
 
 [node name="MenuImage" type="TextureRect" parent="."]
 layout_mode = 1
-anchors_preset = 8
+anchors_preset = 13
 anchor_left = 0.5
-anchor_top = 0.5
 anchor_right = 0.5
-anchor_bottom = 0.5
+anchor_bottom = 1.0
 offset_left = -252.0
-offset_top = -360.0
 offset_right = 252.0
-offset_bottom = 360.0
 grow_horizontal = 2
 grow_vertical = 2
 texture = ExtResource("2_7a404")
@@ -106,22 +102,19 @@ autostart = true
 
 [node name="PausedHint" type="Label" parent="."]
 visible = false
+custom_minimum_size = Vector2(504, 0)
 layout_mode = 1
 anchors_preset = 8
 anchor_left = 0.5
 anchor_top = 0.5
 anchor_right = 0.5
 anchor_bottom = 0.5
-offset_left = -156.0
-offset_top = -214.0
-offset_right = 164.0
-offset_bottom = -182.0
+offset_left = -249.0
+offset_top = -222.0
+offset_right = 255.0
+offset_bottom = -174.0
 grow_horizontal = 2
 grow_vertical = 2
-theme_override_colors/font_color = Color(0.756863, 0.898039, 0.917647, 1)
-theme_override_colors/font_shadow_color = Color(0, 0, 0, 1)
-theme_override_colors/font_outline_color = Color(0.121569, 0.239216, 0.254902, 1)
-theme_override_fonts/font = ExtResource("3_7a404")
 theme_override_font_sizes/font_size = 48
 text = "[ PAUSED ]"
 horizontal_alignment = 1
@@ -131,16 +124,20 @@ metadata/_edit_lock_ = true
 
 [node name="HintBackground" type="ColorRect" parent="PausedHint"]
 show_behind_parent = true
-custom_minimum_size = Vector2(488, 308)
+custom_minimum_size = Vector2(504, 308)
 layout_mode = 1
-anchors_preset = 15
-anchor_right = 1.0
-anchor_bottom = 1.0
-offset_left = -4.0
-offset_right = -4.0
+anchors_preset = 8
+anchor_left = 0.5
+anchor_top = 0.5
+anchor_right = 0.5
+anchor_bottom = 0.5
+offset_left = -255.0
+offset_top = -154.0
+offset_right = 249.0
+offset_bottom = 154.0
 grow_horizontal = 2
 grow_vertical = 2
-color = Color(0.156863, 0.156863, 0.156863, 0.784314)
+color = Color(0.180392, 0.172549, 0.231373, 0.784314)
 metadata/_edit_lock_ = true
 
 [node name="MarginBox" type="MarginContainer" parent="."]
@@ -150,9 +147,9 @@ anchor_left = 0.5
 anchor_top = 1.0
 anchor_right = 0.5
 anchor_bottom = 1.0
-offset_left = -240.0
-offset_top = -314.0
-offset_right = 240.0
+offset_left = -260.0
+offset_top = -400.0
+offset_right = 260.0
 grow_horizontal = 2
 grow_vertical = 0
 theme_override_constants/margin_bottom = 60
@@ -161,6 +158,8 @@ metadata/_edit_lock_ = true
 
 [node name="VBox" type="VBoxContainer" parent="MarginBox"]
 layout_mode = 2
+size_flags_horizontal = 4
+size_flags_vertical = 0
 theme_override_constants/separation = 10
 metadata/_edit_lock_ = true
 
@@ -168,6 +167,8 @@ metadata/_edit_lock_ = true
 visible = false
 custom_minimum_size = Vector2(480, 56)
 layout_mode = 2
+size_flags_horizontal = 4
+size_flags_vertical = 4
 focus_neighbor_top = NodePath("../BackButton")
 focus_neighbor_bottom = NodePath("../PasswordButton")
 focus_next = NodePath("../PasswordButton")
@@ -178,6 +179,8 @@ metadata/_edit_lock_ = true
 [node name="NewGameButton" type="Button" parent="MarginBox/VBox"]
 custom_minimum_size = Vector2(480, 56)
 layout_mode = 2
+size_flags_horizontal = 4
+size_flags_vertical = 4
 focus_neighbor_top = NodePath("../../../ExitMargin/ExitButton")
 focus_neighbor_bottom = NodePath("../PasswordButton")
 focus_next = NodePath("../PasswordButton")
@@ -188,6 +191,8 @@ metadata/_edit_lock_ = true
 [node name="PasswordButton" type="Button" parent="MarginBox/VBox"]
 custom_minimum_size = Vector2(480, 56)
 layout_mode = 2
+size_flags_horizontal = 4
+size_flags_vertical = 4
 focus_neighbor_top = NodePath("../NewGameButton")
 focus_neighbor_bottom = NodePath("../ScoresButton")
 focus_next = NodePath("../ScoresButton")
@@ -198,6 +203,8 @@ metadata/_edit_lock_ = true
 [node name="ScoresButton" type="Button" parent="MarginBox/VBox"]
 custom_minimum_size = Vector2(480, 56)
 layout_mode = 2
+size_flags_horizontal = 4
+size_flags_vertical = 4
 focus_neighbor_top = NodePath("../PasswordButton")
 focus_neighbor_bottom = NodePath("../SettingsButton")
 focus_next = NodePath("../SettingsButton")
@@ -208,6 +215,8 @@ metadata/_edit_lock_ = true
 [node name="SettingsButton" type="Button" parent="MarginBox/VBox"]
 custom_minimum_size = Vector2(480, 56)
 layout_mode = 2
+size_flags_horizontal = 4
+size_flags_vertical = 4
 focus_neighbor_top = NodePath("../ScoresButton")
 focus_neighbor_bottom = NodePath("../CreditsButton")
 focus_next = NodePath("../CreditsButton")
@@ -218,10 +227,13 @@ metadata/_edit_lock_ = true
 [node name="CreditsButton" type="Button" parent="MarginBox/VBox"]
 custom_minimum_size = Vector2(480, 56)
 layout_mode = 2
+size_flags_horizontal = 4
+size_flags_vertical = 4
 focus_neighbor_top = NodePath("../SettingsButton")
 focus_neighbor_bottom = NodePath("../../../ExitMargin/ExitButton")
 focus_next = NodePath("../../../ExitMargin/ExitButton")
 focus_previous = NodePath("../SettingsButton")
+disabled = true
 text = "Credits"
 metadata/_edit_lock_ = true
 
@@ -229,6 +241,8 @@ metadata/_edit_lock_ = true
 visible = false
 custom_minimum_size = Vector2(480, 56)
 layout_mode = 2
+size_flags_horizontal = 4
+size_flags_vertical = 4
 focus_neighbor_top = NodePath("../SettingsButton")
 focus_neighbor_bottom = NodePath("../ResumeButton")
 focus_next = NodePath("../ResumeButton")

--- a/zoo-escape/Scenes/Core/MenuSettings.tscn
+++ b/zoo-escape/Scenes/Core/MenuSettings.tscn
@@ -90,20 +90,19 @@ metadata/_edit_lock_ = true
 [node name="Header" type="Label" parent="VBox"]
 custom_minimum_size = Vector2(0, 80)
 layout_mode = 2
-theme_override_fonts/font = ExtResource("2_a0my0")
 theme_override_font_sizes/font_size = 48
 text = "SETTINGS"
 horizontal_alignment = 1
 metadata/_edit_lock_ = true
 
 [node name="CloseButton" type="Button" parent="VBox/Header"]
-custom_minimum_size = Vector2(64, 64)
+custom_minimum_size = Vector2(48, 48)
 layout_mode = 1
 anchors_preset = 1
 anchor_left = 1.0
 anchor_right = 1.0
-offset_left = -64.0
-offset_bottom = 64.0
+offset_left = -48.0
+offset_bottom = 48.0
 grow_horizontal = 0
 focus_neighbor_top = NodePath("../../DeadzoneGroup/DeadzoneSlider")
 focus_neighbor_bottom = NodePath("../../MasterGroup/MasterSlider")

--- a/zoo-escape/Scripts/Core/MenuScores.gd
+++ b/zoo-escape/Scripts/Core/MenuScores.gd
@@ -56,15 +56,15 @@ func _ready() -> void:
 
 # Called when an InputEvent is detected
 func _input(event: InputEvent) -> void:
-	if !visible:
+	if !visible || !event.is_pressed() || event.is_echo():
 		return
 	
 	var buttonType := -1
-	if event.is_action_pressed("DigitalRight"):
+	if event.is_action("DigitalRight"):
 		buttonType = buttonTypes.NEXT
-	elif event.is_action_pressed("DigitalLeft"):
+	elif event.is_action("DigitalLeft"):
 		buttonType = buttonTypes.PREV
-	elif event.is_action_pressed("CancelButton"):
+	elif event.is_action("CancelButton"):
 		buttonType = buttonTypes.CLOSE
 	
 	if buttonType != -1:
@@ -126,6 +126,14 @@ func getScoreData() -> void:
 # Called by the MenuManager to show this window
 func showMenu() -> void:
 	getScoreData() # Update variables and retrieve the first set of score data
+	var btn: buttonTypes
+	if !buttons[buttonTypes.NEXT].disabled:
+		btn = buttonTypes.NEXT
+	elif !buttons[buttonTypes.PREV].disabled:
+		btn = buttonTypes.PREV
+	else:
+		btn = buttonTypes.PLAY
+	buttons[btn].call_deferred("grab_focus")
 	show()
 
 
@@ -139,25 +147,25 @@ func returnToLastMenu() -> void:
 func resetWindow() -> void:
 	levelName.text = "Unnamed Level"
 	levelPass.text = "Password: ----"
-	for tHold in thresholds:
+	for tHold: Label in thresholds:
 		tHold.text = "--"
-	for mBox in moveBoxes:
+	for mBox: Label in moveBoxes:
 		mBox.text = "--"
-	for tBox in timeBoxes:
+	for tBox: Label in timeBoxes:
 		tBox.text = "--"
-	for sBox in scoreBoxes:
+	for sBox: Label in scoreBoxes:
 		sBox.text = "--"
-	for rBox in ratingBoxes:
+	for rBox: TextureRect in ratingBoxes:
 		rBox.texture = null
 
 
 # Called to enable/disable NextButton / PrevButton when appropriate
 func toggleButtons() -> void:
-	var isFirst = scoreIndex == 0
-	var isLast = scoreIndex == highScoresSize - 1
-	var isSingle = highScoresSize == 1
-	var nextNeighbor = "../NextButton"
-	var prevNeighbor = "../PrevButton"
+	var isFirst := scoreIndex == 0
+	var isLast := scoreIndex == highScoresSize - 1
+	var isSingle := highScoresSize == 1
+	var nextNeighbor := "../NextButton"
+	var prevNeighbor := "../PrevButton"
 	
 	# Enable/disable buttons
 	buttons[buttonTypes.PREV].disabled = isSingle || isFirst
@@ -207,9 +215,9 @@ func onButtonPressed(btnType: buttonTypes) -> void:
 func onButtonMouseEntered(btnType: buttonTypes) -> void:
 	var button: Button = buttons[btnType]
 	if !button.disabled: # Make the button grab_focus
-		button.grab_focus()
+		button.call_deferred("grab_focus")
 
 
 # Event handler for when a menu button receives focus
 func onButtonFocusEntered(btnType: buttonTypes) -> void:
-	buttons[btnType].grab_click_focus()
+	buttons[btnType].call_deferred("grab_click_focus")

--- a/zoo-escape/Scripts/Core/MenuSettings.gd
+++ b/zoo-escape/Scripts/Core/MenuSettings.gd
@@ -128,7 +128,7 @@ func returnToLastMenu() -> void:
 		Data.saveSettingsData()
 		settingsChanged = false
 	SoundControl.playCue(SoundControl.down, 1.4)
-	focusGroup = groupTypes.NONE
+	updateDescriptionHint(groupTypes.CLOSE) # This removes any theme overrides from control groups
 	GoBack.emit()
 
 


### PR DESCRIPTION
- When leaving the settings window, the added theme overrides now get removed
- When returning to the high scores window, the script now selects either the next button, previous button, or play button, depending on disabled state
- Disabled the Credits button since it's a missing menu for now
- Updated theme overrides for [PAUSED] label and background on MenuMain
- Added type hinting in a few places that got missed